### PR TITLE
회원 엔티티, 리포지토리, 서비스 구현하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,23 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 1. spring mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// 2. javax.mail
+	implementation 'javax.mail:mail:1.4.7'
+
+	// 3. Spring Context Support
+	implementation 'org.springframework:spring-context-support:5.3.9'
+
+	// 4. redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// 5. jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/house/pigeon/common/aop/CustomValidationAdvice.java
+++ b/src/main/java/com/house/pigeon/common/aop/CustomValidationAdvice.java
@@ -1,0 +1,41 @@
+package com.house.pigeon.common.aop;
+
+import com.house.pigeon.common.exception.CustomValidationException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Aspect
+@Component
+public class CustomValidationAdvice {
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping) || " +
+            "@annotation(org.springframework.web.bind.annotation.PutMapping) || " +
+            "@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+    public void requestMapping() {}
+
+    @Around("requestMapping()")
+    public Object validationAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object[] args = proceedingJoinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof BindingResult bindingResult) {
+                if (bindingResult.hasErrors()) {
+                    Map<String, String> errorMap = new HashMap<>();
+                    for (FieldError error : bindingResult.getFieldErrors()) {
+                        errorMap.put(error.getField(), error.getDefaultMessage());
+                    }
+                    throw new CustomValidationException("유효성 검사 실패", errorMap);
+                }
+            }
+        }
+        return proceedingJoinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/house/pigeon/common/email/EmailConfig.java
+++ b/src/main/java/com/house/pigeon/common/email/EmailConfig.java
@@ -1,0 +1,48 @@
+package com.house.pigeon.common.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private Integer port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender mailSender() {//JAVA MAILSENDER 인터페이스를 구현한 객체를 빈으로 등록하기 위함.
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();//JavaMailSender 의 구현체를 생성하고
+        mailSender.setHost(host);// 속성을 넣기 시작합니다. 이메일 전송에 사용할 SMTP 서버 호스트를 설정
+        mailSender.setPort(port);// 465로 포트를 지정
+        mailSender.setUsername(username);//네이버 ID를 넣습니다.
+        mailSender.setPassword(password.substring(1));//네이버 비밀번호를 넣습니다.
+
+        Properties javaMailProperties = new Properties();//JavaMail의 속성을 설정하기 위해 Properties 객체를 생성
+        javaMailProperties.put("mail.transport.protocol", "smtp");//프로토콜로 smtp 사용
+        javaMailProperties.put("mail.smtp.auth", "true");//smtp 서버에 인증이 필요
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");//SSL 소켓 팩토리 클래스 사용
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
+        javaMailProperties.put("mail.debug", "true");//디버깅 정보 출력
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.naver.com");//smtp 서버의 ssl 인증서를 신뢰
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");//사용할 ssl 프로토콜 버젼
+
+        mailSender.setJavaMailProperties(javaMailProperties);//mailSender에 우리가 만든 properties 넣고
+
+        return mailSender;//빈으로 등록한다.
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomAPIException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomAPIException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomAPIException extends RuntimeException {
+    public CustomAPIException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomDataAlreadyExistsException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomDataAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomDataAlreadyExistsException extends RuntimeException {
+    public CustomDataAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomDataNotFoundException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomDataNotFoundException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomDataNotFoundException extends RuntimeException {
+    public CustomDataNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomExpiredTokenException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomExpiredTokenException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomExpiredTokenException extends RuntimeException {
+    public CustomExpiredTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomForbiddenException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomForbiddenException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomForbiddenException extends RuntimeException {
+    public CustomForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomInvalidAuthNumberException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomInvalidAuthNumberException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomInvalidAuthNumberException extends RuntimeException {
+    public CustomInvalidAuthNumberException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomJwtException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomJwtException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomJwtException extends RuntimeException{
+    public CustomJwtException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomNullPointerException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomNullPointerException.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.common.exception;
+
+public class CustomNullPointerException extends RuntimeException {
+    public CustomNullPointerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/CustomValidationException.java
+++ b/src/main/java/com/house/pigeon/common/exception/CustomValidationException.java
@@ -1,0 +1,16 @@
+package com.house.pigeon.common.exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class CustomValidationException extends RuntimeException {
+
+    private final Map<String, String> errorMap;
+
+    public CustomValidationException(String message, Map<String, String> errorMap) {
+        super(message);
+        this.errorMap = errorMap;
+    }
+}

--- a/src/main/java/com/house/pigeon/common/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/house/pigeon/common/exception/handler/CustomExceptionHandler.java
@@ -1,0 +1,84 @@
+package com.house.pigeon.common.exception.handler;
+
+import com.house.pigeon.common.exception.*;
+import com.house.pigeon.common.response.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @ExceptionHandler(CustomAPIException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ResponseEntity<HttpResponse<Void>> apiException(CustomAPIException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomDataNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
+    public ResponseEntity<HttpResponse<Void>> dataNotFoundException(CustomDataNotFoundException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), NOT_FOUND);
+    }
+
+    @ExceptionHandler(CustomForbiddenException.class)
+    @ResponseStatus(FORBIDDEN)
+    public ResponseEntity<HttpResponse<Void>> forbiddenException(CustomForbiddenException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), FORBIDDEN);
+    }
+
+    @ExceptionHandler(CustomValidationException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ResponseEntity<HttpResponse<Map<String, String>>> validationApiException(CustomValidationException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), e.getErrorMap()), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomJwtException.class)
+    @ResponseStatus(UNAUTHORIZED)
+    public ResponseEntity<HttpResponse<Void>> JWTException(CustomJwtException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(CustomDataAlreadyExistsException.class)
+    @ResponseStatus(CONFLICT)
+    public ResponseEntity<HttpResponse<Void>> dataAlreadyExistsException(CustomDataAlreadyExistsException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), CONFLICT);
+    }
+
+    @ExceptionHandler(CustomExpiredTokenException.class)
+    @ResponseStatus(GONE)
+    public ResponseEntity<HttpResponse<Void>> expiredTokenException(CustomExpiredTokenException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), GONE);
+    }
+
+    @ExceptionHandler(CustomNullPointerException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ResponseEntity<HttpResponse<Void>> nullPointerException(CustomNullPointerException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomInvalidAuthNumberException.class)
+    @ResponseStatus(UNAUTHORIZED)
+    public ResponseEntity<HttpResponse<Void>> invalidAuthNumberException(CustomInvalidAuthNumberException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/JWTProvider.java
+++ b/src/main/java/com/house/pigeon/common/jwt/JWTProvider.java
@@ -1,0 +1,150 @@
+package com.house.pigeon.common.jwt;
+
+import com.house.pigeon.common.exception.CustomJwtException;
+import com.house.pigeon.common.jwt.model.request.CreateJWTRequest;
+import com.house.pigeon.role.model.RoleType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+@Slf4j
+@Getter
+@Component
+public class JWTProvider {
+
+    private final byte[] ACCESS_TOKEN_SECRET_KEY;
+    private final byte[] REFRESH_TOKEN_SECRET_KEY;
+
+    public final static Long ACCESS_TOKEN_EXPIRE_COUNT = 30 * 60 * 1000L; // 30 minutes
+    public final static Long REFRESH_TOKEN_EXPIRE_COUNT = 7 * 24 * 60 * 60 * 1000L; // 7 days
+
+    public JWTProvider(@Value("${jwt.key.access}") String accessSecret,
+                       @Value("${jwt.key.refresh}") String refreshSecret) {
+        this.ACCESS_TOKEN_SECRET_KEY = accessSecret.getBytes(StandardCharsets.UTF_8);
+        this.REFRESH_TOKEN_SECRET_KEY = refreshSecret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String createAccessToken(CreateJWTRequest request) {
+        return createToken(request, ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_COUNT, "access-token");
+    }
+
+    public String createRefreshToken(CreateJWTRequest request) {
+        return createToken(request, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_COUNT, "refresh-token");
+    }
+
+    private String createToken(CreateJWTRequest request, byte[] secretKey, Long expireCount, String tokenType) {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        ZonedDateTime validityDate = now.plus(Duration.ofMillis(expireCount));
+
+        String jti = UUID.randomUUID().toString();
+
+        Claims claims = Jwts.claims().setSubject(request.email());
+        claims.put("userId", request.memberId());
+        claims.put("roles", request.roleTypes().stream()
+                .map(RoleType::name)
+                .toList());
+        claims.put("tokenType", tokenType);
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims)
+                .setIssuer("pigeon")
+                .setSubject(request.email())
+                .setAudience("http://localhost:8080")
+                .setExpiration(Date.from(validityDate.toInstant()))
+                .setNotBefore(Date.from(now.toInstant()))
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setId(jti)
+                .signWith(getSigningKey(secretKey), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Key getSigningKey(byte[] secretKey) {
+        return Keys.hmacShaKeyFor(secretKey);
+    }
+
+    public Boolean isTokenExpiringSoon(String token, byte[] secretKey, Long timeInMinutes) {
+        Date expiration = getExpirationTimeFromToken(token, secretKey);
+        Date now = new Date();
+
+        long diffInMinutes = (expiration.getTime() - now.getTime()) / (1000 * 60);
+        return diffInMinutes < timeInMinutes;
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver, byte[] secretKey) {
+        final Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claimsResolver.apply(claims);
+    }
+
+    public Date getExpirationTimeFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, Claims::getExpiration, secretKey);
+    }
+
+    public Long getMemberIdFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, claims -> claims.get("userId", Long.class), secretKey);
+    }
+
+    public List<RoleType> getMemberRolesFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, claims -> {
+            List<String> roles = claims.get("roles", List.class);
+            if (roles == null) {
+                throw new CustomJwtException("토큰에서 권한 정보를 찾을 수 없습니다.");
+            }
+            return roles.stream()
+                    .map(RoleType::valueOf)
+                    .toList();
+        }, secretKey);
+    }
+
+    public String getEmailFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, Claims::getSubject, secretKey);
+    }
+
+    public String getTokenTypeFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, claims -> claims.get("tokenType", String.class), secretKey);
+    }
+
+    public Claims getAllClaimsFromToken(String token, byte[] secretKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Boolean validateToken(String token, byte[] secretKey) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(secretKey))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return true;
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | MissingClaimException e) {
+            log.error("유효하지 않은 JWT: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+        } catch (JwtException e) {
+            log.error("유효하지 않은 JWT 토큰: {}", e.getMessage());
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/house/pigeon/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,88 @@
+package com.house.pigeon.common.jwt;
+
+import com.house.pigeon.common.exception.CustomJwtException;
+import com.house.pigeon.common.jwt.model.request.CreateJWTRequest;
+import com.house.pigeon.common.security.CustomUserDetails;
+import com.house.pigeon.role.model.RoleType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JWTProvider jwtTokenProvider;
+    private final UserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = getTokenFromRequest(request);
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY())) {
+            // Access Token이 유효한 경우,
+            authenticateWithToken(accessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY(), request);
+        } else {
+            // Access Token이 유효하지 않은 경우, Refresh Token을 검사
+            String refreshToken = getRefreshTokenFromRequest(request);
+            if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken, jwtTokenProvider.getREFRESH_TOKEN_SECRET_KEY())) {
+                // Refresh Token이 유효한 경우, 새로운 Access Token 발급
+                String email = jwtTokenProvider.getEmailFromToken(refreshToken, jwtTokenProvider.getREFRESH_TOKEN_SECRET_KEY());
+
+                // 새로운 Access Token 발급 로직을 서비스에서 호출
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+                if (userDetails instanceof CustomUserDetails customUserDetails) {
+                    List<RoleType> roleTypes = customUserDetails.getAuthorities().stream()
+                            .map(authority -> RoleType.valueOf(authority.getAuthority()))
+                            .toList();
+
+                    CreateJWTRequest jwtRequest = new CreateJWTRequest(customUserDetails.getId(), email, roleTypes);
+                    String newAccessToken = jwtTokenProvider.createAccessToken(jwtRequest);
+
+                    response.setHeader("Authorization", "Bearer " + newAccessToken);
+                    authenticateWithToken(newAccessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY(), request);
+                } else {
+                    throw new CustomJwtException("Invalid UserDetails implementation");
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateWithToken(String token, byte[] secretKey, HttpServletRequest request) {
+        String email = jwtTokenProvider.getEmailFromToken(token, secretKey);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        log.info("getTokenFromRequest: {}", bearerToken);
+        return null;
+    }
+
+    private String getRefreshTokenFromRequest(HttpServletRequest request) {
+        return request.getHeader("refresh-token");
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/model/JWTStorageDTO.java
+++ b/src/main/java/com/house/pigeon/common/jwt/model/JWTStorageDTO.java
@@ -1,0 +1,13 @@
+package com.house.pigeon.common.jwt.model;
+
+public record JWTStorageDTO(
+        Long memberId,
+        String refreshToken
+) {
+
+    public static JWTStorageDTO from(TokenStorage tokenStorage) {
+        return new JWTStorageDTO(
+                tokenStorage.getId(),
+                tokenStorage.getToken());
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/model/TokenStorage.java
+++ b/src/main/java/com/house/pigeon/common/jwt/model/TokenStorage.java
@@ -1,0 +1,29 @@
+package com.house.pigeon.common.jwt.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TokenStorage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 512, nullable = false)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    private TokenType tokenType;
+
+    @Builder
+    public TokenStorage(String token, TokenType tokenType) {
+        this.token = token;
+        this.tokenType = tokenType;
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/model/TokenType.java
+++ b/src/main/java/com/house/pigeon/common/jwt/model/TokenType.java
@@ -1,0 +1,14 @@
+package com.house.pigeon.common.jwt.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TokenType {
+    ACCESS_TOKEN("액세스 토큰"),
+    REFRESH_TOKEN("리프레시 토큰");
+
+    public final String token;
+}
+

--- a/src/main/java/com/house/pigeon/common/jwt/model/request/CreateJWTRequest.java
+++ b/src/main/java/com/house/pigeon/common/jwt/model/request/CreateJWTRequest.java
@@ -1,0 +1,16 @@
+package com.house.pigeon.common.jwt.model.request;
+
+import com.house.pigeon.role.model.RoleType;
+import lombok.Builder;
+
+import java.util.List;
+
+public record CreateJWTRequest(
+        Long memberId,
+        String email,
+        List<RoleType> roleTypes
+) {
+    @Builder
+    public CreateJWTRequest {
+    }
+}

--- a/src/main/java/com/house/pigeon/common/jwt/model/request/ReissueRefreshTokenRequest.java
+++ b/src/main/java/com/house/pigeon/common/jwt/model/request/ReissueRefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package com.house.pigeon.common.jwt.model.request;
+
+public record ReissueRefreshTokenRequest(String refreshToken) {
+}

--- a/src/main/java/com/house/pigeon/common/jwt/repository/TokenStorageRepository.java
+++ b/src/main/java/com/house/pigeon/common/jwt/repository/TokenStorageRepository.java
@@ -1,0 +1,11 @@
+package com.house.pigeon.common.jwt.repository;
+
+import com.house.pigeon.common.jwt.model.TokenStorage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenStorageRepository extends JpaRepository<TokenStorage, Long> {
+
+    Optional<TokenStorage> findByToken(String token);
+}

--- a/src/main/java/com/house/pigeon/common/jwt/service/JWTStorageService.java
+++ b/src/main/java/com/house/pigeon/common/jwt/service/JWTStorageService.java
@@ -1,0 +1,32 @@
+package com.house.pigeon.common.jwt.service;
+
+import com.house.pigeon.common.exception.CustomJwtException;
+import com.house.pigeon.common.jwt.model.JWTStorageDTO;
+import com.house.pigeon.common.jwt.model.TokenStorage;
+import com.house.pigeon.common.jwt.model.TokenType;
+import com.house.pigeon.common.jwt.repository.TokenStorageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class JWTStorageService {
+
+    private final TokenStorageRepository tokenStorageRepository;
+
+    public void addToken(String token, TokenType tokenType) {
+        TokenStorage tokenStorage = TokenStorage.builder()
+                .token(token)
+                .tokenType(tokenType)
+                .build();
+
+        tokenStorageRepository.save(tokenStorage);
+    }
+
+    public JWTStorageDTO findToken(String token) {
+        TokenStorage tokenStorage = tokenStorageRepository.findByToken(token)
+                .orElseThrow(() -> new CustomJwtException("존재하지 않는 토큰입니다."));
+
+        return JWTStorageDTO.from(tokenStorage);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/response/HttpResponse.java
+++ b/src/main/java/com/house/pigeon/common/response/HttpResponse.java
@@ -1,0 +1,4 @@
+package com.house.pigeon.common.response;
+
+public record HttpResponse<T>(Integer code, String message, T data) {
+}

--- a/src/main/java/com/house/pigeon/common/security/CustomUserDetails.java
+++ b/src/main/java/com/house/pigeon/common/security/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.house.pigeon.common.security;
+
+
+import com.house.pigeon.member.model.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public Long getId() {
+        return member.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return member.getMemberRoles()
+                .stream()
+                .map(memberRole -> new SimpleGrantedAuthority(memberRole.getRole().getRoleType().name()))
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/house/pigeon/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/house/pigeon/common/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.house.pigeon.common.security;
+
+import com.house.pigeon.member.model.Member;
+import com.house.pigeon.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // CustomUserDetailsService: 스프링 시큐리티와 연동하여 사용자 인증 및 권한 관리를 처리합니다.
+    // 시큐리티로 로그인이 될때, 시큐리티가 loadUserByUsername() 실행해서 username 을 체크!!
+    // 없으면 오류
+    // 있으면 정상적으로 시큐리티 컨텍스트 내부 세션에 로그인된 세션이 만들어진다.
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new InternalAuthenticationServiceException("인증 실패"));
+        // UsernameNotFoundException 으로 처리할지 고민해보자.
+
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/house/pigeon/common/security/config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package com.house.pigeon.common.security.config;
+
+import com.house.pigeon.common.jwt.JwtAuthenticationFilter;
+import com.house.pigeon.common.security.entrypoint.CustomJWTAuthenticationEntryPoint;
+import com.house.pigeon.common.security.handler.CustomJWTAccessDeniedHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Component
+public class SecurityConfig {
+
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJWTAuthenticationEntryPoint customJWTAuthenticationEntryPoint;
+    private final CustomJWTAccessDeniedHandler customJWTAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                        .requestMatchers("/api/v1/**").permitAll()); // TODO: 임시로 모든 요청을 허용
+
+        http
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(customJWTAuthenticationEntryPoint)
+                        .accessDeniedHandler(customJWTAccessDeniedHandler))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) {
+        return http.getSharedObject(AuthenticationManager.class);
+    }
+
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+        corsConfiguration.setAllowedOriginPatterns(List.of("*")); // 모든 허용(React + Next.js + .etc)
+        corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"));
+        corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/house/pigeon/common/security/config/WebConfig.java
+++ b/src/main/java/com/house/pigeon/common/security/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.house.pigeon.common.security.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "http://localhost:8080")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")
+                .allowedHeaders("Authorization", "Cache-Control", "Content-Type")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/house/pigeon/common/security/entrypoint/CustomJWTAuthenticationEntryPoint.java
+++ b/src/main/java/com/house/pigeon/common/security/entrypoint/CustomJWTAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.house.pigeon.common.security.entrypoint;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJWTAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    // AuthenticationEntryPoint 설정: 인증 실패 시 401 Unauthorized 응답을 반환하는 EntryPoint를 설정합니다.
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/src/main/java/com/house/pigeon/common/security/handler/CustomJWTAccessDeniedHandler.java
+++ b/src/main/java/com/house/pigeon/common/security/handler/CustomJWTAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.house.pigeon.common.security.handler;
+
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJWTAccessDeniedHandler implements AccessDeniedHandler {
+
+    // AccessDeniedHandler 설정: 권한 부족 시 403 Forbidden 응답을 반환하는 Handler를 설정합니다.
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+    }
+}

--- a/src/main/java/com/house/pigeon/member/controller/AuthController.java
+++ b/src/main/java/com/house/pigeon/member/controller/AuthController.java
@@ -1,0 +1,74 @@
+package com.house.pigeon.member.controller;
+
+import com.house.pigeon.common.jwt.model.request.ReissueRefreshTokenRequest;
+import com.house.pigeon.common.response.HttpResponse;
+import com.house.pigeon.member.model.EmailCheckDTO;
+import com.house.pigeon.member.model.MemberDTO;
+import com.house.pigeon.member.model.request.CreateMemberRequest;
+import com.house.pigeon.member.model.request.EmailVerificationRequest;
+import com.house.pigeon.member.model.request.LoginMemberRequest;
+import com.house.pigeon.member.model.request.LogoutMemberRequest;
+import com.house.pigeon.member.model.response.LoginMemberResponse;
+import com.house.pigeon.member.service.MailService;
+import com.house.pigeon.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final MemberService memberService;
+    private final MailService mailService;
+
+    @PostMapping
+    public ResponseEntity<HttpResponse<MemberDTO>> saveMember(@RequestBody @Valid CreateMemberRequest request, BindingResult result) {
+        MemberDTO memberDTO = memberService.saveMember(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "회원가입에 성공했습니다.", memberDTO), HttpStatus.CREATED);
+    }
+
+    // 회원 로그인
+    @PostMapping("/login")
+    public ResponseEntity<HttpResponse<LoginMemberResponse>> login(@RequestBody @Valid LoginMemberRequest request, BindingResult result) {
+        LoginMemberResponse loginMemberResponse = memberService.login(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "로그인에 성공했습니다.", loginMemberResponse), HttpStatus.OK);
+    }
+
+    // 회원 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<HttpResponse<Void>> logout(@RequestBody LogoutMemberRequest request) {
+        memberService.logout(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "로그아웃에 성공했습니다.", null), HttpStatus.OK);
+    }
+
+    // JWT 토큰 재발급
+    @PostMapping("/token-reissue")
+    public ResponseEntity<HttpResponse<LoginMemberResponse>> refreshTokenReissue(@RequestBody ReissueRefreshTokenRequest request, BindingResult result) {
+        LoginMemberResponse loginMemberResponse = memberService.refreshTokenReissue(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "토큰을 재발급 합니다.", loginMemberResponse), HttpStatus.OK);
+    }
+
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<HttpResponse<MemberDTO>> getMember(@PathVariable(name = "memberId") Long memberId) {
+        MemberDTO memberDTO = memberService.getMember(memberId);
+        return new ResponseEntity<>(new HttpResponse<>(1, "회원 조회에 성공했습니다.", memberDTO), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/mail/send")
+    public ResponseEntity<HttpResponse<Void>> sendEmail(@RequestBody @Valid EmailVerificationRequest request, BindingResult result) {
+        mailService.sendVerificationEmail(request.email());
+        return new ResponseEntity<>(new HttpResponse<>(1, "유효한 이메일입니다.", null), HttpStatus.OK);
+    }
+
+    @PostMapping("/mail/verify")
+    public ResponseEntity<HttpResponse<Void>> authCheck(@RequestBody @Valid EmailCheckDTO emailCheckDTO) {
+        mailService.verifyAuthNumber(emailCheckDTO);
+        return new ResponseEntity<>(new HttpResponse<>(1, "이메일 인증 번호가 유효합니다.", null), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/EmailCheckDTO.java
+++ b/src/main/java/com/house/pigeon/member/model/EmailCheckDTO.java
@@ -1,0 +1,18 @@
+package com.house.pigeon.member.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record EmailCheckDTO(
+
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효하지 않은 이메일입니다.")
+        @Size(min = 6, max = 32, message = "이메일: 유효하지 않은 이메일입니다.")
+        String email,
+
+        @NotBlank(message = "인증번호: 인증번호를 입력해 주세요")
+        String authNum
+) {
+
+}

--- a/src/main/java/com/house/pigeon/member/model/Member.java
+++ b/src/main/java/com/house/pigeon/member/model/Member.java
@@ -1,0 +1,36 @@
+package com.house.pigeon.member.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", unique = true, nullable = false, updatable = false)
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String phone;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberRole> memberRoles = new ArrayList<>();
+
+    @Builder
+    public Member(Long id, String email, String password, String phone, List<MemberRole> memberRoles) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+        this.memberRoles = memberRoles != null ? memberRoles : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/MemberDTO.java
+++ b/src/main/java/com/house/pigeon/member/model/MemberDTO.java
@@ -1,0 +1,48 @@
+package com.house.pigeon.member.model;
+
+import java.util.List;
+
+public record MemberDTO(
+        Long id,
+        String email,
+        String password,
+        String phone,
+        List<MemberRoleDTO> memberRoles
+) {
+    public static MemberDTO of(String email, String password, String phone) {
+        return new MemberDTO(null, email, password, phone, null);
+    }
+
+    public static MemberDTO of(Long id, String email, String password, String phone, List<MemberRoleDTO> memberRoles) {
+        return new MemberDTO(id, email, password, phone, memberRoles);
+    }
+
+    public static MemberDTO from(Member member) {
+        List<MemberRoleDTO> memberRoleDTOs = member.getMemberRoles().stream()
+                .map(MemberRoleDTO::from)
+                .toList();
+
+        return new MemberDTO(
+                member.getId(),
+                member.getEmail(),
+                member.getPassword(),
+                member.getPhone(),
+                memberRoleDTOs
+        );
+    }
+
+    public Member toEntity() {
+        List<MemberRole> memberRoleEntities = this.memberRoles != null
+                ? this.memberRoles.stream()
+                .map(MemberRoleDTO::toEntity)
+                .toList()
+                : null;
+
+        return Member.builder()
+                .email(this.email)
+                .password(this.password)
+                .phone(this.phone)
+                .memberRoles(memberRoleEntities)
+                .build();
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/MemberRole.java
+++ b/src/main/java/com/house/pigeon/member/model/MemberRole.java
@@ -1,0 +1,31 @@
+package com.house.pigeon.member.model;
+
+import com.house.pigeon.role.model.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_role_id", unique = true, nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Role role;
+
+    @Builder
+    public MemberRole(Member member, Role role) {
+        this.member = member;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/MemberRoleDTO.java
+++ b/src/main/java/com/house/pigeon/member/model/MemberRoleDTO.java
@@ -1,0 +1,39 @@
+package com.house.pigeon.member.model;
+
+import com.house.pigeon.role.model.Role;
+import com.house.pigeon.role.model.RoleDTO;
+
+public record MemberRoleDTO(
+        Long id,
+        Long memberId,
+        Long roleId,
+        RoleDTO role
+) {
+
+    public static MemberRoleDTO of(Long memberId, Long roleId, RoleDTO role) {
+        return new MemberRoleDTO(null, memberId, roleId, role);
+    }
+
+    public static MemberRoleDTO of(Long id, Long memberId, Long roleId, RoleDTO role) {
+        return new MemberRoleDTO(id, memberId, roleId, role);
+    }
+
+    public static MemberRoleDTO from(MemberRole memberRole) {
+        return new MemberRoleDTO(
+                memberRole.getId(),
+                memberRole.getMember().getId(),
+                memberRole.getRole().getId(),
+                RoleDTO.from(memberRole.getRole())
+        );
+    }
+
+    public MemberRole toEntity() {
+        Member memberEntity = Member.builder().id(this.memberId).build();
+        Role roleEntity = this.role.toEntity();
+        return MemberRole.builder()
+                .member(memberEntity)
+                .role(roleEntity)
+                .build();
+    }
+
+}

--- a/src/main/java/com/house/pigeon/member/model/request/CreateMemberRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/CreateMemberRequest.java
@@ -1,0 +1,29 @@
+package com.house.pigeon.member.model.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+public record CreateMemberRequest(
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효하지 않은 이메일입니다.")
+        @Size(min = 6, max = 32, message = "이메일: 유효하지 않은 이메일입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 필수 정보입니다.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
+                , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        String password,
+
+        @NotBlank(message = "휴대전화번호: 필수 정보입니다.")
+        @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        @Size(min = 10, max = 11, message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        String phone
+) {
+
+    @Builder
+    public CreateMemberRequest {
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/request/EmailVerificationRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/EmailVerificationRequest.java
@@ -1,0 +1,15 @@
+package com.house.pigeon.member.model.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record EmailVerificationRequest(
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효하지 않은 이메일입니다.")
+        @Size(min = 6, max = 32, message = "이메일: 유효하지 않은 이메일입니다.")
+        String email
+) {
+
+}
+

--- a/src/main/java/com/house/pigeon/member/model/request/LoginMemberRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/LoginMemberRequest.java
@@ -1,0 +1,19 @@
+package com.house.pigeon.member.model.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LoginMemberRequest(
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효하지 않은 이메일입니다.")
+        @Size(min = 6, max = 32, message = "이메일: 유효하지 않은 이메일입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 필수 정보입니다.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
+                , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/com/house/pigeon/member/model/request/LogoutMemberRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/LogoutMemberRequest.java
@@ -1,0 +1,4 @@
+package com.house.pigeon.member.model.request;
+
+public record LogoutMemberRequest(String refreshToken) {
+}

--- a/src/main/java/com/house/pigeon/member/model/request/UpdateMemberByEmailRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/UpdateMemberByEmailRequest.java
@@ -1,0 +1,4 @@
+package com.house.pigeon.member.model.request;
+
+public record UpdateMemberByEmailRequest() {
+}

--- a/src/main/java/com/house/pigeon/member/model/response/LoginMemberResponse.java
+++ b/src/main/java/com/house/pigeon/member/model/response/LoginMemberResponse.java
@@ -1,0 +1,13 @@
+package com.house.pigeon.member.model.response;
+
+import lombok.Builder;
+
+public record LoginMemberResponse(
+        Long memberId,
+        String accessToken,
+        String refreshToken
+) {
+    @Builder
+    public LoginMemberResponse {
+    }
+}

--- a/src/main/java/com/house/pigeon/member/repository/MemberRepository.java
+++ b/src/main/java/com/house/pigeon/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.house.pigeon.member.repository;
+
+import com.house.pigeon.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
+
+    Boolean existsByPhone(String phone);
+}

--- a/src/main/java/com/house/pigeon/member/repository/MemberRoleRepository.java
+++ b/src/main/java/com/house/pigeon/member/repository/MemberRoleRepository.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.member.repository;
+
+import com.house.pigeon.member.model.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+}

--- a/src/main/java/com/house/pigeon/member/service/MailService.java
+++ b/src/main/java/com/house/pigeon/member/service/MailService.java
@@ -1,0 +1,76 @@
+package com.house.pigeon.member.service;
+
+import com.house.pigeon.common.exception.CustomAPIException;
+import com.house.pigeon.common.exception.CustomInvalidAuthNumberException;
+import com.house.pigeon.member.model.EmailCheckDTO;
+import com.house.pigeon.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisUtil redisUtil;
+
+    // 이메일 인증 번호 생성
+    private Integer generateRandomNumber() {
+        Random random = new Random();
+        StringBuilder randomNumber = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            randomNumber.append(random.nextInt(10));
+        }
+        return Integer.parseInt(randomNumber.toString());
+    }
+
+    // 이메일 전송 메서드
+    public void sendVerificationEmail(String email) {
+        Integer authNumber = generateRandomNumber();
+        String setFrom = "piay801@naver.com";
+        String title = "회원 가입 인증 이메일 입니다.";
+        String content = "임대일 프로젝트를 방문해주셔서 감사합니다." +
+                "<br><br>" +
+                "인증 번호는 " + authNumber + "입니다." +
+                "<br>" +
+                "인증번호를 제대로 입력해주세요";
+
+        sendEmail(setFrom, email, title, content);
+        saveAuthNumberInCache(authNumber, email);
+    }
+
+    // 이메일 전송 로직
+    private void sendEmail(String setFrom, String toMail, String title, String content) {
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");
+            helper.setFrom(setFrom);
+            helper.setTo(toMail);
+            helper.setSubject(title);
+            helper.setText(content, true);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new CustomAPIException("이메일 전송: 이메일 전송에 실패했습니다.");
+        }
+    }
+
+    // 인증 번호를 캐시에 저장
+    private void saveAuthNumberInCache(Integer authNumber, String email) {
+        String authKey = authNumber.toString();
+        redisUtil.setDataExpire(authKey, email, 60 * 5L); // 5분 동안 유효
+    }
+
+    // 인증 번호 확인 메서드
+    public void verifyAuthNumber(EmailCheckDTO emailCheckDTO) {
+        String cachedEmail = redisUtil.getData(emailCheckDTO.authNum());
+        if (!emailCheckDTO.email().equals(cachedEmail)) {
+            throw new CustomInvalidAuthNumberException("인증 번호: 인증 번호가 유효하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/house/pigeon/member/service/MemberRoleService.java
+++ b/src/main/java/com/house/pigeon/member/service/MemberRoleService.java
@@ -1,0 +1,4 @@
+package com.house.pigeon.member.service;
+
+public class MemberRoleService {
+}

--- a/src/main/java/com/house/pigeon/member/service/MemberService.java
+++ b/src/main/java/com/house/pigeon/member/service/MemberService.java
@@ -1,0 +1,182 @@
+package com.house.pigeon.member.service;
+
+import com.house.pigeon.common.exception.CustomDataAlreadyExistsException;
+import com.house.pigeon.common.exception.CustomDataNotFoundException;
+import com.house.pigeon.common.exception.CustomForbiddenException;
+import com.house.pigeon.common.exception.CustomJwtException;
+import com.house.pigeon.common.jwt.JWTProvider;
+import com.house.pigeon.common.jwt.model.TokenStorage;
+import com.house.pigeon.common.jwt.model.TokenType;
+import com.house.pigeon.common.jwt.model.request.CreateJWTRequest;
+import com.house.pigeon.common.jwt.model.request.ReissueRefreshTokenRequest;
+import com.house.pigeon.common.jwt.repository.TokenStorageRepository;
+import com.house.pigeon.common.jwt.service.JWTStorageService;
+import com.house.pigeon.common.security.CustomUserDetailsService;
+import com.house.pigeon.member.model.Member;
+import com.house.pigeon.member.model.MemberDTO;
+import com.house.pigeon.member.model.MemberRole;
+import com.house.pigeon.member.model.request.CreateMemberRequest;
+import com.house.pigeon.member.model.request.LoginMemberRequest;
+import com.house.pigeon.member.model.request.LogoutMemberRequest;
+import com.house.pigeon.member.model.response.LoginMemberResponse;
+import com.house.pigeon.member.repository.MemberRepository;
+import com.house.pigeon.role.model.Role;
+import com.house.pigeon.role.model.RoleType;
+import com.house.pigeon.role.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+    private final JWTProvider jwtProvider;
+
+    private final JWTStorageService jwtStorageService;
+    private final TokenStorageRepository tokenStorageRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public void checkMemberByEmail(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new CustomDataAlreadyExistsException("이메일: 이미 가입된 이메일입니다.");
+        }
+    }
+
+    public void checkMemberByPhone(String phone) {
+        if (memberRepository.existsByPhone(phone)) {
+            throw new CustomDataAlreadyExistsException("휴대전화번호: 이미 등록된 휴대전화번호입니다.");
+        }
+    }
+
+    @Transactional
+    public MemberDTO saveMember(CreateMemberRequest request) {
+        checkMemberByEmail(request.email());
+        checkMemberByPhone(request.phone());
+
+        Member member = Member.builder()
+                .email(request.email())
+                .password(bCryptPasswordEncoder.encode(request.password()))
+                .phone(request.phone())
+                .build();
+
+        Role defaultRole = roleRepository.findByRoleType(RoleType.MEMBER)
+                .orElseThrow(() -> new CustomDataNotFoundException("권한: MEMBER 권한이 등록되어 있지 않습니다."));
+
+        MemberRole memberRole = MemberRole.builder()
+                .member(member)
+                .role(defaultRole)
+                .build();
+
+        member.getMemberRoles().add(memberRole);
+        member = memberRepository.save(member);
+
+        return MemberDTO.from(member);
+    }
+
+    // 회원 로그인
+    @Transactional
+    public LoginMemberResponse login(LoginMemberRequest request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new CustomDataNotFoundException("잘못된 아이디입니다."));
+
+        if (!bCryptPasswordEncoder.matches(request.password(), member.getPassword())) {
+            throw new CustomForbiddenException("잘못된 비밀번호입니다.");
+        }
+
+        List<RoleType> roleTypes = member.getMemberRoles().stream()
+                .map(memberRole -> memberRole.getRole().getRoleType())
+                .toList();
+
+        CreateJWTRequest jwtTokenRequest = CreateJWTRequest.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .roleTypes(roleTypes)
+                .build();
+
+        String accessToken = jwtProvider.createAccessToken(jwtTokenRequest);
+        String refreshToken = jwtProvider.createRefreshToken(jwtTokenRequest);
+
+        jwtStorageService.addToken(refreshToken, TokenType.REFRESH_TOKEN);
+
+        return LoginMemberResponse.builder()
+                .memberId(member.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 회원 로그아웃
+    @Transactional
+    public void logout(LogoutMemberRequest request) {
+//        if(tokenBlacklistRepository.existsByToken(request.refreshToken())) {
+//            throw new CustomJwtException("블랙리스트에 등록된 토큰입니다.");
+//        }
+
+        TokenStorage tokenStorage = tokenStorageRepository.findByToken(request.refreshToken())
+                .orElseThrow(() -> new CustomJwtException("존재하지 않는 토큰입니다."));
+
+//        TokenBlacklist tokenBlacklist = TokenBlacklist.builder()
+//                .token(request.refreshToken())
+//                .build();
+
+        tokenStorageRepository.delete(tokenStorage);
+//        tokenBlacklistRepository.save(tokenBlacklist);
+    }
+
+    // 토큰 재발급
+    @Transactional
+    public LoginMemberResponse refreshTokenReissue(ReissueRefreshTokenRequest request) {
+        Boolean isValidateToken = jwtProvider.validateToken(request.refreshToken(), jwtProvider.getREFRESH_TOKEN_SECRET_KEY());
+        Boolean isRefreshTokenExpiringSoon = jwtProvider.isTokenExpiringSoon(request.refreshToken(), jwtProvider.getREFRESH_TOKEN_SECRET_KEY(), 60 * 24L);
+        Long memberId = jwtProvider.getMemberIdFromToken(request.refreshToken(), jwtProvider.getREFRESH_TOKEN_SECRET_KEY());
+        String email = jwtProvider.getEmailFromToken(request.refreshToken(), jwtProvider.getREFRESH_TOKEN_SECRET_KEY());
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        List<RoleType> roleTypes = userDetails.getAuthorities().stream()
+                .map(authority -> RoleType.valueOf(authority.getAuthority()))
+                .toList();
+
+        CreateJWTRequest createJWTRequest = new CreateJWTRequest(memberId, email, roleTypes);
+
+//        if (tokenBlacklistRepository.existsByToken(request.refreshToken())) {
+//            throw new CustomJwtException("블랙리스트에 등록된 토큰입니다.");
+//        }
+
+        // 리프레시 토큰이 유효하고 만료 시간이 24 시간 이상 남은 경우: 액세스 토큰만 재발행
+        if (isValidateToken && !isRefreshTokenExpiringSoon) {
+            String newAccessToken = jwtProvider.createAccessToken(createJWTRequest);
+
+            return LoginMemberResponse.builder()
+                    .memberId(memberId)
+                    .accessToken(newAccessToken)
+                    .refreshToken(request.refreshToken())
+                    .build();
+        }
+
+        // 리프레시 토큰이 만료되거나 만료 시간이 24시간 미만 남은 경우: 액세스 토큰, 리프레시 토큰 재발행
+        String newAccessToken = jwtProvider.createAccessToken(createJWTRequest);
+        String newRefreshToken = jwtProvider.createRefreshToken(createJWTRequest);
+        return LoginMemberResponse.builder()
+                .memberId(memberId)
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDTO getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomDataNotFoundException("회원: 존재하지 않는 회원입니다."));
+
+        return MemberDTO.from(member);
+    }
+}

--- a/src/main/java/com/house/pigeon/redis/RedisConfig.java
+++ b/src/main/java/com/house/pigeon/redis/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.house.pigeon.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    // Lettuce
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    // Redis Template
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Serializer: Key - Value 타입
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Serializer: Hash 타입
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // Serializer: Default(모든 경우)
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/house/pigeon/redis/RedisUtil.java
+++ b/src/main/java/com/house/pigeon/redis/RedisUtil.java
@@ -1,0 +1,34 @@
+package com.house.pigeon.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final StringRedisTemplate redisTemplate;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public void setData(String key, String value) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/house/pigeon/role/RoleInitializer.java
+++ b/src/main/java/com/house/pigeon/role/RoleInitializer.java
@@ -1,0 +1,28 @@
+package com.house.pigeon.role;
+
+import com.house.pigeon.role.model.Role;
+import com.house.pigeon.role.model.RoleType;
+import com.house.pigeon.role.repository.RoleRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RoleInitializer {
+
+    private final RoleRepository roleRepository;
+
+    @PostConstruct
+    @Transactional
+    public void initRoles() {
+        for (RoleType roleType : RoleType.values()) {
+            if (!roleRepository.existsByRoleType(roleType)) {
+                roleRepository.save(Role.builder()
+                        .roleType(roleType)
+                        .build());
+            }
+        }
+    }
+}

--- a/src/main/java/com/house/pigeon/role/model/Role.java
+++ b/src/main/java/com/house/pigeon/role/model/Role.java
@@ -1,0 +1,33 @@
+package com.house.pigeon.role.model;
+
+import com.house.pigeon.member.model.MemberRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id", unique = true, nullable = false, updatable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType roleType;
+
+    @OneToMany(mappedBy = "role")
+    private final List<MemberRole> memberRoles = new ArrayList<>();
+
+    @Builder
+    public Role(RoleType roleType) {
+        this.roleType = roleType;
+    }
+}

--- a/src/main/java/com/house/pigeon/role/model/RoleDTO.java
+++ b/src/main/java/com/house/pigeon/role/model/RoleDTO.java
@@ -1,0 +1,27 @@
+package com.house.pigeon.role.model;
+
+public record RoleDTO(
+        Long id,
+        RoleType roleType
+) {
+    public static RoleDTO of(RoleType roleType) {
+        return new RoleDTO(null, roleType);
+    }
+
+    public static RoleDTO of(Long id, RoleType roleType) {
+        return new RoleDTO(id, roleType);
+    }
+
+    public static RoleDTO from(Role role) {
+        return new RoleDTO(
+                role.getId(),
+                role.getRoleType()
+        );
+    }
+
+    public Role toEntity() {
+        return Role.builder()
+                .roleType(this.roleType)
+                .build();
+    }
+}

--- a/src/main/java/com/house/pigeon/role/model/RoleType.java
+++ b/src/main/java/com/house/pigeon/role/model/RoleType.java
@@ -1,0 +1,14 @@
+package com.house.pigeon.role.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum RoleType {
+    MEMBER("회원"),
+    MANAGER("관리자"),
+    ADMIN("운영자");
+
+    private final String name;
+}

--- a/src/main/java/com/house/pigeon/role/repository/RoleRepository.java
+++ b/src/main/java/com/house/pigeon/role/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.house.pigeon.role.repository;
+
+import com.house.pigeon.role.model.Role;
+import com.house.pigeon.role.model.RoleType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Boolean existsByRoleType(RoleType roleType);
+    Optional<Role> findByRoleType(RoleType roleType);
+}

--- a/src/main/java/com/house/pigeon/role/service/RoleService.java
+++ b/src/main/java/com/house/pigeon/role/service/RoleService.java
@@ -1,0 +1,7 @@
+package com.house.pigeon.role.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=pigeon


### PR DESCRIPTION
*한 번에 너무 많은 코드를 PR 하게 됐다... 이번만 이렇게 진행하고, 설정 및 API 엔드포인트에 따라 간단하게 설명을 정리한다.

1. gitignore, 의존성 추가하기
    리포지토리에 .yml 파일을 제외한다. 이메일, 레디스, JWT 사용에 필요한 의존성을 추가했다.

2. 회원-회원권한-권한 설정하기
    회원은 여러 개의 권한을 가질 수 있도록 설정했다. grantedauthority 에서 리스트로 받기 때문에 그대로 했다.
    기본적으로 회원 가입에 성공하면 MEMBER 권한을 부여 받는다.

3. 이메일 인증 구현하기
    이메일 인증으로 유효한 회원인지 검증한다.

4. 공통사항 구현하기
    공통적인 응답 형식 레코드를 구현했다. 예외 클래스와 AOP 구현했다.

5. 시큐리티, JWT 구현하기
    JWT 사용에 따라 스프링 시큐리티 커스텀을 했다. 리프레시 토큰 관리를 위해 로테이션 혹은 블랙리스트 도입을 고민하는 중이다.

6. 레디스 설정하기
    지금 이메일은 레디스에서, JWT는 RDBMS 에서 관리중이다. 모두 레디스로 이관할 것이다.

7. 권한 생성하기
    권한 컨트롤러, 서비스, 리포지토리 틀을 생성했다. 필요에따라서 더 생성이 필요하다.

This closes #3 