### PR TITLE
회원 권한 단건 조회, 수정 API 구현하기

### DIFF
--- a/src/main/java/com/house/pigeon/member/controller/admin/MemberAdminController.java
+++ b/src/main/java/com/house/pigeon/member/controller/admin/MemberAdminController.java
@@ -1,0 +1,33 @@
+package com.house.pigeon.member.controller.admin;
+
+import com.house.pigeon.common.response.HttpResponse;
+import com.house.pigeon.member.model.request.UpdateMemberRolesRequest;
+import com.house.pigeon.member.model.response.MemberRolesResponse;
+import com.house.pigeon.member.service.MemberRoleService;
+import com.house.pigeon.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+@RestController
+public class MemberAdminController {
+
+    private final MemberRoleService memberRoleService;
+
+    @GetMapping("/{memberId}/role")
+    public ResponseEntity<HttpResponse<MemberRolesResponse>> getMemberRoles(@PathVariable Long memberId) {
+        MemberRolesResponse memberRoles = memberRoleService.getMemberRoles(memberId);
+        return new ResponseEntity<>(new HttpResponse<>(1, "회원권한 조회에 성공했습니다.", memberRoles), HttpStatus.OK);
+    }
+
+    @PutMapping("/{memberId}/role")
+    public ResponseEntity<HttpResponse<MemberRolesResponse>> updateMemberRoles(
+            @PathVariable Long memberId,
+            @RequestBody UpdateMemberRolesRequest request) {
+        MemberRolesResponse memberRoles = memberRoleService.updateMemberRoles(memberId, request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "회원권한 변경에 성공했습니다.", memberRoles), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/house/pigeon/member/model/Member.java
+++ b/src/main/java/com/house/pigeon/member/model/Member.java
@@ -1,7 +1,10 @@
 package com.house.pigeon.member.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,5 +35,19 @@ public class Member {
         this.password = password;
         this.phone = phone;
         this.memberRoles = memberRoles != null ? memberRoles : new ArrayList<>();
+    }
+
+    public void addMemberRole(MemberRole memberRole) {
+        if (!memberRoles.contains(memberRole)) {
+            memberRoles.add(memberRole);
+            memberRole.setMember(this);
+        }
+    }
+
+    public void removeMemberRole(MemberRole memberRole) {
+        if (memberRoles.contains(memberRole)) {
+            memberRoles.remove(memberRole);
+            memberRole.setMember(null);
+        }
     }
 }

--- a/src/main/java/com/house/pigeon/member/model/MemberRole.java
+++ b/src/main/java/com/house/pigeon/member/model/MemberRole.java
@@ -2,10 +2,7 @@ package com.house.pigeon.member.model;
 
 import com.house.pigeon.role.model.Role;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,15 +14,41 @@ public class MemberRole {
     @Column(name = "member_role_id", unique = true, nullable = false, updatable = false)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
     private Role role;
 
     @Builder
     public MemberRole(Member member, Role role) {
         this.member = member;
         this.role = role;
+    }
+
+    public void setMember(Member member) {
+        // 기존 member와의 관계를 제거
+        if (this.member != null) {
+            this.member.getMemberRoles().remove(this);
+        }
+        this.member = member;
+        if (member != null && !member.getMemberRoles().contains(this)) {
+            member.getMemberRoles().add(this);
+        }
+    }
+
+    public void setRole(Role role) {
+        // 기존 role과의 관계를 제거
+        if (this.role != null) {
+            this.role.getMemberRoles().remove(this);
+        }
+        this.role = role;
+        if (role != null && !role.getMemberRoles().contains(this)) {
+            role.getMemberRoles().add(this);
+        }
     }
 }

--- a/src/main/java/com/house/pigeon/member/model/request/UpdateMemberRolesRequest.java
+++ b/src/main/java/com/house/pigeon/member/model/request/UpdateMemberRolesRequest.java
@@ -1,0 +1,10 @@
+package com.house.pigeon.member.model.request;
+
+import com.house.pigeon.role.model.RoleType;
+
+import java.util.List;
+
+public record UpdateMemberRolesRequest(
+        List<RoleType> roleTypes
+) {
+}

--- a/src/main/java/com/house/pigeon/member/model/response/MemberRolesResponse.java
+++ b/src/main/java/com/house/pigeon/member/model/response/MemberRolesResponse.java
@@ -1,0 +1,14 @@
+package com.house.pigeon.member.model.response;
+
+import com.house.pigeon.role.model.RoleType;
+import lombok.Builder;
+
+import java.util.List;
+
+public record MemberRolesResponse(
+        List<RoleType> roleTypes
+) {
+    @Builder
+    public MemberRolesResponse {
+    }
+}

--- a/src/main/java/com/house/pigeon/member/repository/MemberRoleRepository.java
+++ b/src/main/java/com/house/pigeon/member/repository/MemberRoleRepository.java
@@ -1,7 +1,13 @@
 package com.house.pigeon.member.repository;
 
+import com.house.pigeon.member.model.Member;
 import com.house.pigeon.member.model.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+    List<MemberRole> findByMemberId(Long memberId);
+    List<MemberRole> findByMember(Member member);
 }

--- a/src/main/java/com/house/pigeon/member/service/MailService.java
+++ b/src/main/java/com/house/pigeon/member/service/MailService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;

--- a/src/main/java/com/house/pigeon/member/service/MemberRoleService.java
+++ b/src/main/java/com/house/pigeon/member/service/MemberRoleService.java
@@ -1,4 +1,80 @@
 package com.house.pigeon.member.service;
 
+import com.house.pigeon.common.exception.CustomDataNotFoundException;
+import com.house.pigeon.member.model.Member;
+import com.house.pigeon.member.model.MemberRole;
+import com.house.pigeon.member.model.request.UpdateMemberRolesRequest;
+import com.house.pigeon.member.model.response.MemberRolesResponse;
+import com.house.pigeon.member.repository.MemberRepository;
+import com.house.pigeon.member.repository.MemberRoleRepository;
+import com.house.pigeon.role.model.Role;
+import com.house.pigeon.role.model.RoleType;
+import com.house.pigeon.role.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
 public class MemberRoleService {
+
+    private final MemberRepository memberRepository;
+    private final MemberRoleRepository memberRoleRepository;
+    private final RoleRepository roleRepository;
+
+    @Transactional(readOnly = true)
+    public MemberRolesResponse getMemberRoles(Long memberId) {
+        // 회원 존재 여부 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomDataNotFoundException("회원: 회원이 존재하지 않습니다."));
+
+        List<MemberRole> memberRoles = memberRoleRepository.findByMemberId(member.getId());
+        List<RoleType> roleTypes = memberRoles.stream()
+                .map(memberRole -> memberRole.getRole().getRoleType())
+                .toList();
+
+        return MemberRolesResponse.builder()
+                .roleTypes(roleTypes)
+                .build();
+    }
+
+    @Transactional
+    public MemberRolesResponse updateMemberRoles(Long memberId, UpdateMemberRolesRequest request) {
+        // 회원 존재 여부 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomDataNotFoundException("회원: 회원이 존재하지 않습니다."));
+
+        // 기존 권한 제거
+        List<MemberRole> existingRoles = memberRoleRepository.findByMember(member);
+        for (MemberRole memberRole : existingRoles) {
+            member.removeMemberRole(memberRole);
+            memberRole.getRole().removeMemberRole(memberRole);
+        }
+        memberRoleRepository.deleteAll(existingRoles);
+
+        // 새로운 권한 추가
+        List<MemberRole> newMemberRoles = request.roleTypes().stream()
+                .map(roleType -> {
+                    Role role = roleRepository.findByRoleType(roleType)
+                            .orElseThrow(() -> new CustomDataNotFoundException("권한: 해당 권한이 존재하지 않습니다."));
+                    MemberRole memberRole = MemberRole.builder().member(member).role(role).build();
+                    member.addMemberRole(memberRole);
+                    role.addMemberRole(memberRole);
+                    return memberRole;
+                })
+                .toList();
+
+        memberRoleRepository.saveAll(newMemberRoles);
+
+        // 새로운 권한 리스트 생성
+        List<RoleType> roleTypes = newMemberRoles.stream()
+                .map(memberRole -> memberRole.getRole().getRoleType())
+                .toList();
+
+        return MemberRolesResponse.builder()
+                .roleTypes(roleTypes)
+                .build();
+    }
 }

--- a/src/main/java/com/house/pigeon/role/model/Role.java
+++ b/src/main/java/com/house/pigeon/role/model/Role.java
@@ -30,4 +30,18 @@ public class Role {
     public Role(RoleType roleType) {
         this.roleType = roleType;
     }
+
+    public void addMemberRole(MemberRole memberRole) {
+        if (!memberRoles.contains(memberRole)) {
+            memberRoles.add(memberRole);
+            memberRole.setRole(this);
+        }
+    }
+
+    public void removeMemberRole(MemberRole memberRole) {
+        if (memberRoles.contains(memberRole)) {
+            memberRoles.remove(memberRole);
+            memberRole.setRole(null);
+        }
+    }
 }


### PR DESCRIPTION
회원 권한 관리에 필요한 두 개의 API를 구현한다.

- 회원 권한 단건 조회하기
- 회원 권한 수정하기
두 API 모두 관리자만이 접근할 수 있도록 구성한다.

가장 핵심은 무결성과 일관성을 갖도록 연관 관계 메서드를 구현하는 것이다. 일대다, 다대일에 해당하는 회원과 권한에는 추가, 삭제 메서드와 함께 연관관계 엔티티로부터 각 자신의 필드를 수정하는 로직이 담겨져 있다.

그리고 연관관계 메서드 안에는 set 메서드 안에 수정하는 값이 처리를 적절하게 수행할 수 있도록 작성했다.

정라하자면 회원 권한 수정 요청에 따라 데이터베이스에서 일관성 있는 처리를 수행하고, 자바 코드 안에서도 각 필드마다 일관성과 무결성을 가질 수 있도록 동일한 처리를 수행하는 메서드를 구현했다.

This close #17 